### PR TITLE
fix: copy binary instead of parent folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,6 @@ RUN set -ex ;\
 
 FROM alpine
 
-COPY --from=builder /app/checkmate /usr/bin/checkmate
+COPY --from=builder /app/checkmate/checkmate /usr/bin/checkmate
 
 ENTRYPOINT ["/usr/bin/checkmate"]


### PR DESCRIPTION
```shell
$ docker run --rm -ti sha256:012b07ead7dabca3ab747bc32a64ef7d32bfddd59ac37651270fbcfeea1795dd --version
checkmate 0.1.0
```

fixes #4 