### PR TITLE
feature(checkmate): use color-eyre for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,9 +130,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "checkmate"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "checkmk-client",
  "clap",
+ "color-eyre",
  "serde",
  "serde_yaml",
 ]
@@ -194,6 +188,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +254,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -442,6 +473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +529,12 @@ checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -567,6 +610,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "percent-encoding"
@@ -781,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +908,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -931,6 +999,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -988,6 +1078,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "want"

--- a/checkmate/Cargo.toml
+++ b/checkmate/Cargo.toml
@@ -9,8 +9,8 @@ authors = [
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.72"
 checkmk-client = { path = "../checkmk-client/" }
+color-eyre = "0.6.2"
 clap = { version = "4.3.19", features = ["derive", "env"] }
 serde = { version = "1.0.176", features = ["derive"] }
 serde_yaml = "0.9.25"

--- a/checkmate/src/config.rs
+++ b/checkmate/src/config.rs
@@ -28,9 +28,9 @@ pub use rulesets::{
     Ruleset,
 };
 
-use anyhow::{
-    Context,
+use color_eyre::eyre::{
     Result,
+    WrapErr,
 };
 use serde::Deserialize;
 use std::{
@@ -48,7 +48,7 @@ pub struct DeclarativeConfig {
 impl DeclarativeConfig {
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let config: DeclarativeConfig = serde_yaml::from_reader(std::fs::File::open(path)?)
-            .context("Failed to parse declarative config")?;
+            .wrap_err("Failed to parse declarative config")?;
         config.verify_constraints()?;
         Ok(config)
     }
@@ -60,7 +60,7 @@ impl DeclarativeConfig {
             for host in folder.hosts.iter().flatten() {
                 if let Some(existing_path) = discovered_hosts.insert(&host.host_name, &folder.path)
                 {
-                    anyhow::bail!(
+                    color_eyre::eyre::bail!(
                         "Host {} is defined both in folder {} and folder {}",
                         host.host_name,
                         existing_path.display(),

--- a/checkmate/src/main.rs
+++ b/checkmate/src/main.rs
@@ -22,11 +22,12 @@ use crate::config::{
     DeclarativeConfig,
     Folder,
 };
-use anyhow::Result;
 use checkmk_client::changes::ChangesApi;
 use clap::Parser;
+use color_eyre::eyre::Result;
 
 fn main() -> Result<()> {
+    color_eyre::install()?;
     let args = cli::Args::parse();
     let client =
         checkmk_client::Client::new(&args.server_url, &args.site, &args.username, &args.secret)?;


### PR DESCRIPTION
Eyre provides a lot more details (specifically an extremely usable backtrace) than anyhow, greatly improving debuggability in the face of an error.

WO-1291