### PR TITLE
chore: have clap wrap help-messages automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -224,6 +231,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "eyre"
@@ -497,6 +514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +773,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -4,7 +4,7 @@ This page lists the licenses of the projects used in Persevere.
 
 ## Overview of licenses
 
-- [Apache License 2.0](#Apache-2.0) (110)
+- [Apache License 2.0](#Apache-2.0) (115)
 - [MIT License](#MIT) (25)
 - [ISC License](#ISC) (4)
 - [BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License](#BSD-3-Clause) (1)
@@ -1500,6 +1500,7 @@ This page lists the licenses of the projects used in Persevere.
 - [clap 4.5.20]( https://github.com/clap-rs/clap )
 - [colorchoice 1.0.3]( https://github.com/rust-cli/anstyle.git )
 - [is_terminal_polyfill 1.70.1]( https://github.com/polyfill-rs/is_terminal_polyfill )
+- [terminal_size 0.4.0]( https://github.com/eminence/terminal-size )
 
 <pre>
                                  Apache License
@@ -3187,12 +3188,14 @@ limitations under the License.
 - [autocfg 1.4.0]( https://github.com/cuviper/autocfg )
 - [backtrace 0.3.71]( https://github.com/rust-lang/backtrace-rs )
 - [base64 0.22.1]( https://github.com/marshallpierce/rust-base64 )
+- [bitflags 2.6.0]( https://github.com/bitflags/bitflags )
 - [bumpalo 3.16.0]( https://github.com/fitzgen/bumpalo )
 - [cc 1.1.31]( https://github.com/rust-lang/cc-rs )
 - [cfg-if 1.0.0]( https://github.com/alexcrichton/cfg-if )
 - [color-eyre 0.6.3]( https://github.com/eyre-rs/eyre )
 - [color-spantrace 0.2.1]( https://github.com/eyre-rs/eyre )
 - [equivalent 1.0.1]( https://github.com/cuviper/equivalent )
+- [errno 0.3.9]( https://github.com/lambda-fairy/rust-errno )
 - [eyre 0.6.12]( https://github.com/eyre-rs/eyre )
 - [fnv 1.0.7]( https://github.com/servo/rust-fnv )
 - [form_urlencoded 1.2.1]( https://github.com/servo/rust-url )
@@ -3206,12 +3209,14 @@ limitations under the License.
 - [indexmap 2.6.0]( https://github.com/indexmap-rs/indexmap )
 - [js-sys 0.3.72]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys )
 - [lazy_static 1.5.0]( https://github.com/rust-lang-nursery/lazy-static.rs )
+- [linux-raw-sys 0.4.14]( https://github.com/sunfishcode/linux-raw-sys )
 - [log 0.4.22]( https://github.com/rust-lang/log )
 - [mime 0.3.17]( https://github.com/hyperium/mime )
 - [object 0.32.2]( https://github.com/gimli-rs/object )
 - [once_cell 1.20.2]( https://github.com/matklad/once_cell )
 - [percent-encoding 2.3.1]( https://github.com/servo/rust-url/ )
 - [rustc-demangle 0.1.24]( https://github.com/rust-lang/rustc-demangle )
+- [rustix 0.38.37]( https://github.com/bytecodealliance/rustix )
 - [rustls-pemfile 2.2.0]( https://github.com/rustls/pemfile )
 - [rustls 0.23.15]( https://github.com/rustls/rustls )
 - [smallvec 1.13.2]( https://github.com/servo/rust-smallvec )

--- a/checkmate/Cargo.toml
+++ b/checkmate/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 [dependencies]
 checkmk-client = { path = "../checkmk-client/" }
 color-eyre = "0.6.3"
-clap = { version = "4.5.20", features = ["derive", "env"] }
+clap = { version = "4.5.20", features = ["derive", "env", "wrap_help"] }
 serde = { version = "1.0.213", features = ["derive"] }
 serde_yaml = "0.9.34+deprecated"

--- a/checkmate/src/cli.rs
+++ b/checkmate/src/cli.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 
 /// Configure checkmk declaratively using checkmate by providing a configuration file.
 #[derive(Debug, Parser)]
-#[command(version, about)]
+#[command(version, about, max_term_width = 100)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,


### PR DESCRIPTION
This makes the long help messages far easier to read than they otherwise are.