### PR TITLE
fix: small aspects of third-party licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: cargo about generate -o ./THIRD_PARTY_LICENSES.md ./.tools/cargo-about-markdown-template.hbs
     - name: Verify `THIRD_PARTY_LICENSES.md` is up-to-date
       run: |
-        git diff --exit-code --quiet ./THIRD_PARTY_LICENSES.md
+        git diff --exit-code ./THIRD_PARTY_LICENSES.md
         if [ $? -ne 0 ]; then
           echo "THIRD_PARTY_LICENSES.md is out of date. Please run 'cargo about generate -o ./THIRD_PARTY_LICENSES.md ./.tools/cargo-about-markdown-template.hbs' locally, compare what has changed and commit the changes."
           exit 1

--- a/.tools/cargo-about-markdown-template.hbs
+++ b/.tools/cargo-about-markdown-template.hbs
@@ -1,6 +1,6 @@
 # Third Party Licenses
 
-This page lists the licenses of the projects used in Persevere.
+This page lists the licenses of the projects used in Checkmate.
 
 ## Overview of licenses
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Options:
 Checkmate is licensed under the Apache License, Version 2.0, (see [LICENSE](LICENSE) or <https://www.apache.org/licenses/LICENSE-2.0>).
 
 Checkmate internally makes use of various open-source projects.
-You can find a full list of these projects and their licenses in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+You can find a full list of these projects and their licenses in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
 
 ### Contribution
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third Party Licenses
 
-This page lists the licenses of the projects used in Persevere.
+This page lists the licenses of the projects used in Checkmate.
 
 ## Overview of licenses
 


### PR DESCRIPTION
- Print the diff if there is one, to make understanding what needs to be fixed easier.
- Fix wrong copy-pasted project name.
- Fix link to license file from README.